### PR TITLE
WIP - Add hover effect. Closes #9.

### DIFF
--- a/addon/webextension/background.js
+++ b/addon/webextension/background.js
@@ -34,8 +34,106 @@ class PersistentPageModificationEffect {
       .donotdelete {
         transform: scaleY(-1);
         display: inline-block;
-      }`
+      }
 
+      .donotdelete-tooltip {
+        display: inline-block;
+        transform: scaleY(-1) translateY(50%) !important;
+        position: absolute;
+        visibility: hidden;
+        background: #e9e9eb;
+        padding: 4px;
+        font-size: 12px;
+        min-width: 100px;
+        text-align: center;
+        border-radius: 3px;
+        border: 1px solid #bebdbd;
+        box-shadow: var(--standard-box-shadow);
+        color: black;
+      }
+
+      .donotdelete-tooltip a {
+        color: blue !important;
+        text-decoration: underline;
+      }
+
+      /* Show the tooltip when hovering */
+      .donotdelete:hover .donotdelete-tooltip {
+        visibility: visible;
+        z-index: 50;
+      }
+
+      /* Dynamic horizontal centering */
+      [data-tooltip-position="top"],
+      [data-tooltip-position="bottom"] {
+        left: 50%;
+        transform: translateX(-50%);
+      }
+
+      /* Dynamic vertical centering */
+      [data-tooltip-position="right"],
+      [data-tooltip-position="left"] {
+        top: 50%;
+        transform: translateY(-50%);
+      }
+
+      [data-tooltip-position="top"] {
+        bottom: 100%;
+        margin-bottom: 0;
+      }
+
+      [data-tooltip-position="right"] {
+        left: 100%;
+        margin-left: 0;
+      }
+
+      [data-tooltip-position="bottom"] {
+        top: 100%;
+        margin-top: 0;
+      }
+
+      [data-tooltip-position="left"] {
+        right: 100%;
+        margin-right: 0;
+      }
+
+      /* Dynamic horizontal centering for the tooltip */
+      [data-tooltip-position="top"]:after,
+      [data-tooltip-position="bottom"]:after {
+        left: 50%;
+        margin-left: -6px;
+      }
+
+      /* Dynamic vertical centering for the tooltip */
+      [data-tooltip-position="right"]:after,
+      [data-tooltip-position="left"]:after {
+        top: 50%;
+        margin-top: -6px;
+      }
+
+      [data-tooltip-position="top"]:after {
+        bottom: 100%;
+        border-width: 6px 6px 0;
+        border-top-color: #000;
+      }
+
+      [data-tooltip-position="right"]:after {
+        left: 100%;
+        border-width: 6px 6px 6px 0;
+        border-right-color: #000;
+      }
+
+      [data-tooltip-position="bottom"]:after {
+        top: 100%;
+        border-width: 0 6px 6px;
+        border-bottom-color: #000;
+      }
+
+      [data-tooltip-position="left"]:after {
+        right: 100%;
+        border-width: 6px 0 6px 6px;
+        border-left-color: #000;
+      }`;
     this.wordSet = new Set(wordArray);
     this.insertCSSOnAllTabs();
     this.addListeners();

--- a/addon/webextension/content-script.js
+++ b/addon/webextension/content-script.js
@@ -2,21 +2,21 @@
 
 /* global findAndReplaceDOMText */
 
-
-
 function findAndReplace(wordList) {
   // the ones we actually find and substitute
   let seen = new Set();
   for (let word of wordList) {
     // do over all p, div
-    document.querySelectorAll('p, div').forEach(function (node) {
+    document.querySelectorAll("p, h1, h2, h3").forEach(function (node) {
       // attempt a replace
       let r = findAndReplaceDOMText(
         node,
-        {find:new RegExp(word,'ig'),
-         wrap:'span',
-         wrapClass: "donotdelete",
-         preset:"prose"}
+        {
+          find:new RegExp(word,"ig"),
+          wrap:"span",
+          wrapClass: "donotdelete",
+          preset: "prose",
+        }
       );
       // if we had a match, a 'revert' will be there.
       if (r.reverts.length) {
@@ -26,6 +26,19 @@ function findAndReplace(wordList) {
       }
     });
   }
+
+  document.querySelectorAll(".donotdelete").forEach((node) => {
+    const hoverEle = document.createElement("span");
+    hoverEle.innerHTML = `
+      Mr. Robot something something.
+      <br>
+      <a href="http://www.mozilla.org" target="_blank">
+        Learn more
+      </a>`;
+    hoverEle.classList.add("donotdelete-tooltip");
+    hoverEle.setAttribute("data-tooltip-position", "right");
+    node.appendChild(hoverEle);
+  });
 
     // append the ones we saw as a result
     if (document.querySelector('#wanted')) {
@@ -59,3 +72,4 @@ async function sendMessage(msg) {
 
 // get word list from background script, then do it!
 sendMessage({ type: "getList" }).then(findAndReplace);
+


### PR DESCRIPTION
![mrrobotpageeffect](https://user-images.githubusercontent.com/17437436/33701069-c78ec0bc-dad1-11e7-9f36-5c46e57e624e.gif)

I discovered why we were seeing multiple "span" elements wrapped around the same matching word -- we were looking for "div" and "p" elements to check, and frequently, a "div" would have nested "div"s and "p"s, so if a word was in one of the nested elements, it'd get wrapped multiple times. I have changed the `querySelectorAll` to look for "p", "h1", "h2" and "h3" now, which are not commonly nested within each other. A quick check on the Mozilla privacy page showed they are never nested within each other for that page.

Loose ends:
* There is currently a race condition with addon start-up between the background script and content scripts being loaded into existing tabs. The content script immediately sends a message to the background script to get the word list, sometimes before it is listening, throwing an error. Currently, this means some of the time on "web-ext run", the content script executes correctly, and sometimes it throws and does nothing. This seems like a chicken and egg problem to me, so I would appreciate ideas.
* The page linked on the hover effect tooltip element currently opens in a new window, rather than a new tab. This is unusual behavior, since I am using an "a" element with target="_blank". Do we care?
* While the fix above for multiple wrapped "span" elements should help some with the performance issue ("this addon is slowing down Firefox"), we should check to see if we are still receiving the warning.
* The CSS for the hover effect adds quite a bit of CSS. Currently the position of the tooltip is to the right of the word, but there are styles in case we'd like to try "left", "bottom" and "top". Perhaps we should consider moving it to an external stylesheet now?