### PR TITLE
Fix hover effect loading glitch; only flip words inside p elements

### DIFF
--- a/addon/webextension/background.js
+++ b/addon/webextension/background.js
@@ -183,7 +183,6 @@ class PersistentPageModificationEffect {
     */
   connected(p) {
     this.portFromCS = p;
-    this.portFromCS.postMessage({type: "backgroundConnected"});
     this.portFromCS.onMessage.addListener((m) => {
       switch (m.type) {
         case "getList":
@@ -209,6 +208,7 @@ class PersistentPageModificationEffect {
       for (let tab of tabs) {
         if (this.protocolIsApplicable(tab.url)) {
           await browser.tabs.insertCSS(tab.id, this.CSS);
+          this.portFromCS.postMessage({type: "cssLoaded"});
         }
       }
     });
@@ -217,6 +217,7 @@ class PersistentPageModificationEffect {
     browser.tabs.onUpdated.addListener(async (id, changeInfo, tab) => {
       if (this.protocolIsApplicable(tab.url) && tab.status === "complete") {
         await browser.tabs.insertCSS(id, this.CSS);
+        this.portFromCS.postMessage({type: "cssLoaded"});
       }
     });
   }

--- a/addon/webextension/content-script.js
+++ b/addon/webextension/content-script.js
@@ -11,7 +11,7 @@
 var myPort = browser.runtime.connect({name:"port-from-cs"});
 myPort.onMessage.addListener(function(m) {
   switch (m.type) {
-    case "backgroundConnected":
+    case "cssLoaded":
       myPort.postMessage({ type: "getList" });
       break;
     case "getList":
@@ -52,27 +52,14 @@ function findAndReplace(wordList) {
     hoverEle.setAttribute("data-tooltip-position", "right");
     node.appendChild(hoverEle);
 
-    setTimeout(()=>{
     // eslint-disable-next-line no-unsanitized/property
     hoverEle.innerHTML = `
     Can you trust your perceptions?
     You chose this... a reminder of the forces at work in your world.
     If you no longer wish to peer through the looking glass, you can
-    <br/><a href="${SUPPORTURL}" target="_blank" rel="noopener noreferrer">return to blissful ignorance</a>`;
-    },300);
-
+    <br/><a href="${SUPPORTURL}" target="_blank" rel="noopener noreferrer">
+    return to blissful ignorance</a>`;
   });
-
-  // between 1-5 seconds, flip them back, but keep the over.  see #22
-  const delayToRevert = (4*Math.random() + 2)*1000;
-  setTimeout(()=>{
-    document.querySelectorAll('.donotdelete').
-      forEach(node=>{
-          node.classList.add("donotdelete-revert");
-          setTimeout(()=>node.removeChild(node.lastChild),5000);
-    });
-  },delayToRevert);
-
 }
 
 /**

--- a/addon/webextension/content-script.js
+++ b/addon/webextension/content-script.js
@@ -94,11 +94,9 @@ function wrapWith (element, config) {
     // optional: Accept node always.  Same a 'no function' here.
     { acceptNode: function(node) {
         // Logic to determine whether to accept, reject or skip node
-
-        // skip scripts and styles
+        // Only wrap words inside <p> elements
         const tag = node.parentElement.tagName;
-        const skipped_tags = ["STYLE", "SCRIPT", "CANVAS", "SVG"]
-        if (skipped_tags.includes(tag)) {
+        if (tag !== "P") {
           return NodeFilter.FILTER_REJECT;
         }
         return NodeFilter.FILTER_ACCEPT;

--- a/addon/webextension/content-script.js
+++ b/addon/webextension/content-script.js
@@ -54,10 +54,12 @@ function findAndReplace(wordList) {
 
     // eslint-disable-next-line no-unsanitized/property
     hoverEle.innerHTML = `
-    Can you trust your perceptions?
-    You chose this... a reminder of the forces at work in your world.
-    If you no longer wish to peer through the looking glass, you can
-    <br/><a href="${SUPPORTURL}" target="_blank" rel="noopener noreferrer">
+    Can you trust your perceptions?<br>
+    You chose this... a reminder of<br>
+    the forces at work in your world.<br>
+    If you no longer wish to peer<br>
+    through the looking glass, you can<br/>
+    <a href="${SUPPORTURL}" target="_blank" rel="noopener noreferrer">
     return to blissful ignorance</a>`;
   });
 }
@@ -123,7 +125,23 @@ function wrapWith (element, config) {
       var word = p.insertBefore(document.createElement(wrapTag), node);
       word.appendChild(document.createTextNode(mid));
       word.className = wrapClass;
+      checkForOverflow(word);
     }
     node.nodeValue = text;
+  }
+}
+
+// Naive check for overflow:hidden on parent/grandparent element of word
+// to have it display properly when it would otherwise be hidden;
+// does not catch all cases.
+function checkForOverflow(word) {
+  const wordParent = word.parentElement;
+  const wordParentStyle = getComputedStyle(wordParent);
+  const wordGrandparent = wordParent.parentElement;
+  const wordGrandparentStyle = getComputedStyle(wordGrandparent);
+  if (wordParentStyle.overflow === "hidden") {
+    wordParent.style.overflow = "visible";
+  } else if (wordGrandparentStyle.overflow === "hidden") {
+    wordGrandparent.style.overflow = "visible";
   }
 }


### PR DESCRIPTION
Same as PR #35 which couldn't be re-opened since the forked repo was deleted.

This PR will:
* Fix the display issues discussed in PR35.
* Only wrap match words with `<span>` if they are inside a `<p>`